### PR TITLE
Fixed Syntax Error

### DIFF
--- a/wishify/src/pages/Event.jsx
+++ b/wishify/src/pages/Event.jsx
@@ -49,6 +49,7 @@ const Event = () => {
   });
 
   return (
+    <>
     <Navbar></Navbar>
     
     <EventSection>
@@ -92,6 +93,7 @@ const Event = () => {
         </div>
       </Sidebar>
     </EventSection>
+    </>
   );
 };
 export default Event;

--- a/wishify/src/pages/Profile.jsx
+++ b/wishify/src/pages/Profile.jsx
@@ -182,6 +182,7 @@ const Profile = () => {
       />
 
     </section>
+    </>
   )
 }
 


### PR DESCRIPTION
Was running the Wishify site, and discovered two React Fragments were missing. The site would not load due to the issue. This should fix it.